### PR TITLE
Webb/fix JIT hot reload

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -11,7 +11,6 @@ module.exports = {
   devOptions: {
     tailwindConfig: "./tailwind.config.js",
   },
-  plugins: ["@snowpack/plugin-postcss"],
   buildOptions: {
     /* ... */
   },

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     /* ... */
   },
   devOptions: {
-    tailwindConfig: "./tailwind.config.js",
+    /* ... */
   },
   buildOptions: {
     /* ... */


### PR DESCRIPTION
Ran into this while interviewing yesterday,

There appears to be conflict between snowpack and tailwind's JIT compiler that prevents the snowpack HMR to auto-refresh the page when making changes to .css files.

The change I made here appears to resolve the primary issue. But, it's worth checking that the JIT compiler is still producing the desired outcome. 