### PR TITLE
Add documentation on removing Tailwind and using css

### DIFF
--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -4,7 +4,6 @@
 /** @type {import("snowpack").SnowpackUserConfig } */
 module.exports = {
   mount: {},
-  plugins: ["@snowpack/plugin-postcss"],
   packageOptions: {
     /* ... */
   },

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,5 +1,7 @@
 /* If you do not plan on using Tailwind,
- * feel free to delete the `@tailwind` imports.
+ * delete the `@tailwind` imports and the `tailwindConfig` key
+ * from `nowpack.config.js` and re-run `npm run start` to enable
+ * hot reloading of css.
  **/
 @tailwind base;
 @tailwind components;
@@ -9,7 +11,6 @@
  * Note that this uses PostCSS which always nests rules
  * with a `&` prefix.
  **/
-
 body {
   background: #ffefff;
 


### PR DESCRIPTION
Hi @benjtinsley! 

A proactive applicant submitted a PR righting pointing out that vanilla css hot reloading is not currently working  (#4).
That was a regression from when I configured Tailwind dev mode 😞   

Could you confirm that:
1. Out of the box Tailwind hot reloading works and is speedy
2. Following the instructions for removing Tailwind (located in `src/index.css`) makes vanilla css hot reloading work

cc @dmurphy1 

